### PR TITLE
Change Python version accordingly to Search repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## How to Use
 
-To use the BBS_BBG_poc notebook, first make sure to have Python version at least 3.6. To be able to install Blue
+To use the BBS_BBG_poc notebook, first make sure to have Python version at least 3.7. To be able to install Blue
 Brain Search package correctly, it is also import to set up MySQL (see [link](https://pypi.org/project/mysqlclient)) for instructions to install it depending on your OS).
 If necessary, create first a virtual environment.
 


### PR DESCRIPTION
This PR changes README.md instructions regarding python version accordingly to [Search repo](https://github.com/BlueBrain/Search) and its new [PR-242](https://github.com/BlueBrain/Search/pull/242)

@eugeniashurko @MFSY Could you confirm which python versions you are supporting for BBG ? 