### PR TITLE
Add concrete values for environment variables (from Search repo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,14 @@ export SEARCH_ENGINE_URL=<value>
 export TEXT_MINING_URL=<value>
 ```
 
-where `<value>` has to be replaced by the correct value.
+where `<value>` has to be replaced by the correct value. For instance, in case of the setup described by the [Blue
+Brain Search - Getting Started](https://github.com/BlueBrain/Search#getting-started), we shall use
 
+```bash
+export DB_URL=$HOSTNAME:$DATABASE_PORT/$DATABASE_NAME
+export SEARCH_ENGINE_URL=http://$HOSTNAME:$SEARCH_PORT
+export TEXT_MINING_URL=http://$HOSTNAME:$MINING_PORT
+```
 
 Next, set the paths to the Nexus-forge configuration and the ontology linking data as the following environment variables:
 


### PR DESCRIPTION
To avoid duplicates for instructions between [Search-Graph-Examples repo](https://github.com/BlueBrain/Search-Graph-Examples) and [Search repo](https://github.com/BlueBrain/Search), we decided to put concrete examples of values for the environment variables in this README.md file (see [comment](https://github.com/BlueBrain/Search/pull/238#discussion_r576957971) from [PR-238](https://github.com/BlueBrain/Search/pull/238)). 