### PR TITLE
Allow using .env files for configuring environment variables.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+export ONTOLOGY_LINKING_DATA_FILE="<path_to_file>"
+export SEARCH_ENGINE_URL="http://<host>:<port>"
+export TEXT_MINING_URL="http://<host>:<port>"
+export DB_URL="<host>:<port>/<database>"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /venv/
 .ipynb_checkpoints/
 .idea/
+.env*
+!.env.example


### PR DESCRIPTION
To use the example notebook the user has to define these environment variables:
```bash
export ONTOLOGY_LINKING_DATA_FILE="<path_to_file>"
export SEARCH_ENGINE_URL="http://<host>:<port>"
export TEXT_MINING_URL="http://<host>:<port>"
export DB_URL="<host>:<port>/<database>"
```

The easiest is to save them in a `.env` file once and source it every time you start jupyter.

Although not critical for this particular case, it's good practise to include `.env` in the `.gitignore` file. Additionally I'm proposing to include a `.env.example` file to make setting up the environment maximally simple.